### PR TITLE
Add Support for RLIKE

### DIFF
--- a/beam-mysql-haskell.cabal
+++ b/beam-mysql-haskell.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.2.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -35,6 +35,7 @@ library
       Database.Beam.MySQL.Backend
       Database.Beam.MySQL.Connection
       Database.Beam.MySQL.FromField
+      Database.Beam.MySQL.MySQLSpecific
       Database.Beam.MySQL.Syntax
       Database.Beam.MySQL.Syntax.Delete
       Database.Beam.MySQL.Syntax.Expression

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                beam-mysql-haskell
-version:             0.10.0.0
+version:             0.10.1.0
 github:              "himura/beam-mysql-haskell"
 license:             MIT
 license-file:        LICENSE

--- a/src/Database/Beam/MySQL/MySQLSpecific.hs
+++ b/src/Database/Beam/MySQL/MySQLSpecific.hs
@@ -1,0 +1,24 @@
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
+
+module Database.Beam.MySQL.MySQLSpecific (rlike_) where
+
+import Database.Beam.Backend.SQL (BeamSqlBackendIsString)
+import Database.Beam.MySQL.Backend (MySQL)
+import Database.Beam.MySQL.Syntax.Expression
+    ( MySQLExpressionSyntax
+        ( MySQLExpressionSyntax
+        , fromMySQLExpression
+        )
+    )
+import Database.Beam.MySQL.Syntax.Type (emit)
+import Database.Beam.Query (QGenExpr (..))
+
+rlike_
+    :: (BeamSqlBackendIsString MySQL text)
+    => QGenExpr ctxt MySQL s text
+    -- ^ String to search
+    -> QGenExpr ctxt MySQL s text
+    -- ^ Regular expression to search for
+    -> QGenExpr ctxt MySQL s Bool
+rlike_ (QExpr s) (QExpr re) =
+    QExpr $ \t -> MySQLExpressionSyntax $ fromMySQLExpression (s t) <> emit " RLIKE " <> fromMySQLExpression (re t)


### PR DESCRIPTION
# Overview

Add `rlike_` function which allows users to perform regular expression matching in SQL queries using MySQL's `RLIKE` operator.

# Changes Made

- **New Module**: `Database.Beam.MySQL.MySQLSpecific`
  - Added the `rlike_` function, which constructs a SQL expression for `RLIKE`.