### PR TITLE
Add numeric conversions with overflow checks

### DIFF
--- a/src/Database/Beam/MySQL/FromField.hs
+++ b/src/Database/Beam/MySQL/FromField.hs
@@ -87,6 +87,21 @@ instance FromField Int64 where
         MySQLInt64 v -> pure v
         unexpected -> handleUnexpected unexpected
 
+-- | This instance does not support conversion from MySQLDecimal(Scientific)
+--   because the destination `Integer` type is unbounded. Allowing such a conversion
+--   could result in excessive memory usage if malicious input with huge exponents is provided.
+instance FromField Integer where
+    fromField = \case
+        MySQLInt8 v -> pure . fromIntegral $ v
+        MySQLInt16 v -> pure . fromIntegral $ v
+        MySQLInt32 v -> pure . fromIntegral $ v
+        MySQLInt64 v -> pure . fromIntegral $ v
+        MySQLInt8U v -> pure . fromIntegral $ v
+        MySQLInt16U v -> pure . fromIntegral $ v
+        MySQLInt32U v -> pure . fromIntegral $ v
+        MySQLInt64U v -> pure . fromIntegral $ v
+        unexpected -> handleUnexpected unexpected
+
 instance FromField Word8 where
     fromField = \case
         MySQLInt8U v -> pure v

--- a/src/Database/Beam/MySQL/FromField.hs
+++ b/src/Database/Beam/MySQL/FromField.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+
 module Database.Beam.MySQL.FromField
     ( FromField (..)
     , DecodeError (..)
@@ -5,11 +7,13 @@ module Database.Beam.MySQL.FromField
     ) where
 
 import Control.Exception (Exception)
-import Data.Bits (Bits (zeroBits))
+import Data.Bifunctor (first)
+import Data.Bits (Bits (zeroBits), toIntegralSized)
 import Data.ByteString (ByteString)
 import Data.ByteString.Lazy qualified as L
 import Data.Int (Int16, Int32, Int64, Int8)
-import Data.Scientific (Scientific)
+import Data.Kind (Type)
+import Data.Scientific (Scientific, fromFloatDigits, toBoundedInteger, toBoundedRealFloat)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.Lazy qualified as TL
@@ -64,20 +68,20 @@ instance FromField Scientific where
 instance FromField Int8 where
     fromField = \case
         MySQLInt8 v -> pure v
-        unexpected -> handleUnexpected unexpected
+        others -> tryBoundedIntegral others
 
 instance FromField Int16 where
     fromField = \case
         MySQLInt8 v -> pure . fromIntegral $ v
         MySQLInt16 v -> pure v
-        unexpected -> handleUnexpected unexpected
+        others -> tryBoundedIntegral others
 
 instance FromField Int32 where
     fromField = \case
         MySQLInt8 v -> pure . fromIntegral $ v
         MySQLInt16 v -> pure . fromIntegral $ v
         MySQLInt32 v -> pure v
-        unexpected -> handleUnexpected unexpected
+        others -> tryBoundedIntegral others
 
 instance FromField Int64 where
     fromField = \case
@@ -85,7 +89,7 @@ instance FromField Int64 where
         MySQLInt16 v -> pure . fromIntegral $ v
         MySQLInt32 v -> pure . fromIntegral $ v
         MySQLInt64 v -> pure v
-        unexpected -> handleUnexpected unexpected
+        others -> tryBoundedIntegral others
 
 -- | This instance does not support conversion from MySQLDecimal(Scientific)
 --   because the destination `Integer` type is unbounded. Allowing such a conversion
@@ -105,20 +109,20 @@ instance FromField Integer where
 instance FromField Word8 where
     fromField = \case
         MySQLInt8U v -> pure v
-        unexpected -> handleUnexpected unexpected
+        others -> tryBoundedIntegral others
 
 instance FromField Word16 where
     fromField = \case
         MySQLInt8U v -> pure . fromIntegral $ v
         MySQLInt16U v -> pure v
-        unexpected -> handleUnexpected unexpected
+        others -> tryBoundedIntegral others
 
 instance FromField Word32 where
     fromField = \case
         MySQLInt8U v -> pure . fromIntegral $ v
         MySQLInt16U v -> pure . fromIntegral $ v
         MySQLInt32U v -> pure v
-        unexpected -> handleUnexpected unexpected
+        others -> tryBoundedIntegral others
 
 instance FromField Word64 where
     fromField = \case
@@ -126,18 +130,18 @@ instance FromField Word64 where
         MySQLInt16U v -> pure . fromIntegral $ v
         MySQLInt32U v -> pure . fromIntegral $ v
         MySQLInt64U v -> pure v
-        unexpected -> handleUnexpected unexpected
+        others -> tryBoundedIntegral others
 
 instance FromField Float where
     fromField = \case
         MySQLFloat v -> pure v
-        unexpected -> handleUnexpected unexpected
+        others -> tryBoundedRealFloat others
 
 instance FromField Double where
     fromField = \case
         MySQLFloat v -> pure . realToFrac $ v
         MySQLDouble v -> pure v
-        unexpected -> handleUnexpected unexpected
+        others -> tryBoundedRealFloat others
 
 instance FromField ByteString where
     fromField = \case
@@ -182,10 +186,45 @@ instance FromField TimeOfDay where
             | s == zeroBits -> pure v
         unexpected -> handleUnexpected unexpected
 
+tyCon :: forall (a :: Type). (Typeable a) => TyCon
+tyCon = typeRepTyCon $ typeRep @a
+
+tryBoundedIntegral
+    :: forall a
+     . (Integral a, Bounded a, Bits a, Typeable a)
+    => MySQLValue
+    -> Either DecodeError a
+tryBoundedIntegral mv =
+    case mv of
+        MySQLDecimal v -> maybe overflow pure $ toBoundedInteger v
+        MySQLInt8U v -> tryInt v
+        MySQLInt16U v -> tryInt v
+        MySQLInt32U v -> tryInt v
+        MySQLInt64U v -> tryInt v
+        MySQLInt8 v -> tryInt v
+        MySQLInt16 v -> tryInt v
+        MySQLInt32 v -> tryInt v
+        MySQLInt64 v -> tryInt v
+        unexpected -> handleUnexpected unexpected
+  where
+    overflow = Left . DecodeError (tyCon @a) $ DecodeErrorOverflow mv
+
+    tryInt :: forall b. (Integral b, Bits b) => b -> Either DecodeError a
+    tryInt = maybe overflow pure . toIntegralSized
+
+tryBoundedRealFloat :: forall a. (RealFloat a, Typeable a) => MySQLValue -> Either DecodeError a
+tryBoundedRealFloat mv =
+    case mv of
+        MySQLFloat v -> tryRealFloat $ fromFloatDigits v
+        MySQLDouble v -> tryRealFloat $ fromFloatDigits v
+        MySQLDecimal v -> tryRealFloat v
+        unexpected -> handleUnexpected unexpected
+  where
+    tryRealFloat :: Scientific -> Either DecodeError a
+    tryRealFloat = first (\_ -> DecodeError (tyCon @a) (DecodeErrorOverflow mv)) . toBoundedRealFloat
+
 handleUnexpected :: forall a. (Typeable a) => MySQLValue -> Either DecodeError a
 handleUnexpected =
     Left . \case
-        MySQLNull -> DecodeError tyCon DecodeErrorUnexpectedNull
-        unknown -> DecodeError tyCon $ DecodeErrorTypeMismatch unknown
-  where
-    tyCon = typeRepTyCon $ typeRep @a
+        MySQLNull -> DecodeError (tyCon @a) DecodeErrorUnexpectedNull
+        unknown -> DecodeError (tyCon @a) $ DecodeErrorTypeMismatch unknown


### PR DESCRIPTION
- Relaxed restrictions on numeric FromField instances by allowing conversions with overflow checks.
- Added `FromField Integer` instance with strict overflow protection, avoiding memory issues caused by malicious input.
