### PR TITLE
Add MariaDBVector support

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -40,6 +40,7 @@ jobs:
             # image repository: https://github.com/himura/docker-mysql-ci-tweak
             database: ghcr.io/himura/mysql-ci-tweak:8.0-tweak
             healthcheck: mysqladmin ping
+            server-flavor: mysql
           - compiler: ghc-9.10.3
             compilerKind: ghc
             compilerVersion: 9.10.3
@@ -47,6 +48,7 @@ jobs:
             allow-failure: false
             database: mariadb:11.7
             healthcheck: healthcheck.sh --connect --innodb_initialized
+            server-flavor: mariadb
           - compiler: ghc-9.8.4
             compilerKind: ghc
             compilerVersion: 9.8.4
@@ -54,6 +56,7 @@ jobs:
             allow-failure: false
             database: mariadb:11.7
             healthcheck: healthcheck.sh --connect --innodb_initialized
+            server-flavor: mariadb
           - compiler: ghc-9.6.6
             compilerKind: ghc
             compilerVersion: 9.6.6
@@ -61,6 +64,7 @@ jobs:
             allow-failure: false
             database: ghcr.io/himura/mysql-ci-tweak:8.0-tweak
             healthcheck: mysqladmin ping
+            server-flavor: mysql
       fail-fast: false
     services:
       mysql:
@@ -216,6 +220,7 @@ jobs:
         env:
           MYSQL_HOST: mysql
           MYSQL_PORT: 3306
+          TASTY_SERVER_FLAVOR: ${{ matrix.server-flavor }}
       - name: save cache
         if: always()
         uses: actions/cache/save@v4

--- a/beam-mysql-haskell.cabal
+++ b/beam-mysql-haskell.cabal
@@ -41,6 +41,7 @@ library
       Database.Beam.MySQL.Backend
       Database.Beam.MySQL.Connection
       Database.Beam.MySQL.Extra
+      Database.Beam.MySQL.Extra.MariaDBVector
       Database.Beam.MySQL.FromField
       Database.Beam.MySQL.Full
       Database.Beam.MySQL.Logger
@@ -152,10 +153,15 @@ test-suite beam-mysql-haskell-test
   type: exitcode-stdio-1.0
   main-is: Main.hs
   other-modules:
+      Database.Beam.MySQL.Extra.MariaDBVectorIntegrationSpec
+      Database.Beam.MySQL.Extra.MariaDBVectorSpec
+      Database.Beam.MySQL.Extra.Schema
       Database.Beam.MySQL.Syntax.SelectTableSpec
       Database.Beam.MySQL.Syntax.Spec
+      Database.Beam.MySQL.Test.Connection
       Database.Beam.MySQL.Test.Integration
       Database.Beam.MySQL.Test.Schema
+      Database.Beam.MySQL.Test.ServerFlavor
       Database.Beam.MySQL.Test.Util
       Paths_beam_mysql_haskell
   hs-source-dirs:
@@ -193,6 +199,7 @@ test-suite beam-mysql-haskell-test
     , mysql-haskell >=1.0
     , resource-pool
     , scientific ==0.3.*
+    , tagged
     , tasty
     , tasty-hunit
     , tasty-th

--- a/package.yaml
+++ b/package.yaml
@@ -90,6 +90,7 @@ tests:
     dependencies:
     - beam-mysql-haskell
     - resource-pool
+    - tagged
     - tasty
     - tasty-th
     - tasty-hunit

--- a/src/Database/Beam/MySQL/Extra/MariaDBVector.hs
+++ b/src/Database/Beam/MySQL/Extra/MariaDBVector.hs
@@ -1,0 +1,175 @@
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
+
+-- | Support for the @VECTOR@ data type and vector functions introduced in
+-- MariaDB 11.7+.
+--
+-- See the MariaDB documentation:
+-- <https://mariadb.com/kb/en/vector-overview/>.
+--
+-- == Usage
+--
+-- Declare a column with type 'MariaDBVector' in your beam schema. Construct
+-- values with 'fromFloats' and read them back with 'toFloats':
+--
+-- > insertedVec = fromFloats [0.1, 0.2, 0.3]
+--
+-- Use 'vecDistance_', 'vecDistanceCosine_', or 'vecDistanceEuclidean_' in
+-- @ORDER BY@ clauses to perform nearest-neighbour searches.
+--
+-- This module is intended to be imported qualified:
+--
+-- > import qualified Database.Beam.MySQL.Extra.MariaDBVector as MDV
+module Database.Beam.MySQL.Extra.MariaDBVector
+    ( MariaDBVector (..)
+
+      -- * Conversion between @[Float]@ and 'MariaDBVector'
+    , fromFloats
+    , toFloats
+
+      -- * SQL functions
+
+      -- ** Distance
+    , vecDistance_
+    , vecDistanceCosine_
+    , vecDistanceEuclidean_
+
+      -- ** Text representation
+    , vecFromText_
+    , vecToText_
+    ) where
+
+import Data.Binary.Get (Get, getFloatle, isEmpty, runGetOrFail)
+import Data.Binary.Put (putFloatle, runPut)
+import Data.ByteString qualified as S
+import Data.ByteString.Lazy qualified as L
+import Database.Beam.Backend
+import Database.Beam.MySQL.Backend (MySQL)
+import Database.Beam.MySQL.FromField
+import Database.Beam.MySQL.Syntax.Expression
+    ( MySQLExpressionSyntax
+        ( MySQLExpressionSyntax
+        , fromMySQLExpression
+        )
+    )
+import Database.Beam.MySQL.Syntax.Type
+import Database.Beam.MySQL.Syntax.Value
+import Database.Beam.Query (QGenExpr (..))
+
+-- | A value of the MariaDB @VECTOR(N)@ type.
+--
+-- MariaDB stores vectors as a packed sequence of N IEEE 754 single-precision
+-- floats in little-endian byte order. This newtype wraps that raw byte
+-- representation directly; use 'fromFloats' / 'toFloats' to convert to and
+-- from @[Float]@.
+--
+-- The wrapped 'S.ByteString' length must be a multiple of 4 (one @Float@
+-- per 4 bytes). 'fromFloats' guarantees this; if you construct a value
+-- through the 'MariaDBVector' constructor directly, you are responsible
+-- for maintaining the invariant.
+newtype MariaDBVector = MariaDBVector {unMariaDBVector :: S.ByteString}
+    deriving stock (Show, Eq, Ord)
+
+-- | Encode a list of single-precision floats into MariaDB's binary vector
+-- representation (little-endian @float32@ sequence). Total.
+fromFloats :: [Float] -> MariaDBVector
+fromFloats = MariaDBVector . L.toStrict . runPut . mapM_ putFloatle
+
+-- | Decode a 'MariaDBVector' back into a list of 'Float'.
+--
+-- Returns 'Left' if the underlying byte string is not a whole number of
+-- 4-byte floats. Values produced by 'fromFloats' or read back from a
+-- well-formed @VECTOR@ column always decode successfully; a failure
+-- typically indicates a corrupted or hand-constructed 'MariaDBVector'.
+toFloats :: MariaDBVector -> Either String [Float]
+toFloats (MariaDBVector bs) =
+    case runGetOrFail getFloats (L.fromStrict bs) of
+        Left (_, _, err) -> Left err
+        Right (_, _, xs) -> Right xs
+  where
+    getFloats :: Get [Float]
+    getFloats = do
+        e <- isEmpty
+        if e then pure [] else (:) <$> getFloatle <*> getFloats
+
+instance FromBackendRow MySQL MariaDBVector
+
+instance FromField MariaDBVector where
+    fromField = fmap MariaDBVector . fromField
+
+instance HasSqlValueSyntax MySQLValueSyntax MariaDBVector where
+    sqlValueSyntax = sqlValueSyntax . unMariaDBVector
+
+-- | The MariaDB @VEC_DISTANCE(a, b)@ function.
+--
+-- Computes the distance between two vectors using the metric configured
+-- for the column's vector index (set when the index is created). Prefer
+-- this over 'vecDistanceCosine_' / 'vecDistanceEuclidean_' when querying
+-- through an index, so that the executor can use the index.
+--
+-- See <https://mariadb.com/kb/en/vec_distance/>.
+vecDistance_
+    :: QGenExpr ctxt MySQL s MariaDBVector
+    -> QGenExpr ctxt MySQL s MariaDBVector
+    -> QGenExpr ctxt MySQL s Double
+vecDistance_ = vecDistance_' "VEC_DISTANCE"
+
+-- | The MariaDB @VEC_DISTANCE_COSINE(a, b)@ function.
+--
+-- Always computes cosine distance regardless of the column's index metric.
+--
+-- See <https://mariadb.com/kb/en/vec_distance_cosine/>.
+vecDistanceCosine_
+    :: QGenExpr ctxt MySQL s MariaDBVector
+    -> QGenExpr ctxt MySQL s MariaDBVector
+    -> QGenExpr ctxt MySQL s Double
+vecDistanceCosine_ = vecDistance_' "VEC_DISTANCE_COSINE"
+
+-- | The MariaDB @VEC_DISTANCE_EUCLIDEAN(a, b)@ function.
+--
+-- Always computes Euclidean (L2) distance regardless of the column's index
+-- metric.
+--
+-- See <https://mariadb.com/kb/en/vec_distance_euclidean/>.
+vecDistanceEuclidean_
+    :: QGenExpr ctxt MySQL s MariaDBVector
+    -> QGenExpr ctxt MySQL s MariaDBVector
+    -> QGenExpr ctxt MySQL s Double
+vecDistanceEuclidean_ = vecDistance_' "VEC_DISTANCE_EUCLIDEAN"
+
+vecDistance_'
+    :: S.ByteString
+    -> QGenExpr ctxt MySQL s MariaDBVector
+    -> QGenExpr ctxt MySQL s MariaDBVector
+    -> QGenExpr ctxt MySQL s Double
+vecDistance_' fn (QExpr a) (QExpr b) =
+    QExpr $ \t ->
+        MySQLExpressionSyntax $
+            emit fn <> (parens . commas . map fromMySQLExpression $ [a t, b t])
+
+-- | The MariaDB @VEC_FromText(s)@ function.
+--
+-- Parses a JSON array literal such as @"[0.1, 0.2, 0.3]"@ into the binary
+-- vector representation. Useful for inserting vectors from textual sources
+-- or in @WHERE@/@ORDER BY@ clauses without round-tripping through Haskell.
+--
+-- See <https://mariadb.com/kb/en/vec_fromtext/>.
+vecFromText_
+    :: (BeamSqlBackendIsString MySQL text)
+    => QGenExpr ctxt MySQL s text
+    -> QGenExpr ctxt MySQL s MariaDBVector
+vecFromText_ (QExpr vect) =
+    QExpr $ \t -> MySQLExpressionSyntax $ emit "VEC_FromText" <> (parens (fromMySQLExpression (vect t)))
+
+-- | The MariaDB @VEC_ToText(v)@ function.
+--
+-- Renders a vector as a JSON array literal, e.g. @"[0.1,0.2,0.3]"@. Useful
+-- for debugging or for exporting vectors without decoding them on the
+-- client side.
+--
+-- See <https://mariadb.com/kb/en/vec_totext/>.
+vecToText_
+    :: (BeamSqlBackendIsString MySQL text)
+    => QGenExpr ctxt MySQL s MariaDBVector
+    -> QGenExpr ctxt MySQL s text
+vecToText_ (QExpr vtxt) =
+    QExpr $ \t -> MySQLExpressionSyntax $ emit "VEC_ToText" <> (parens (fromMySQLExpression (vtxt t)))

--- a/test/Database/Beam/MySQL/Extra/MariaDBVectorIntegrationSpec.hs
+++ b/test/Database/Beam/MySQL/Extra/MariaDBVectorIntegrationSpec.hs
@@ -1,0 +1,127 @@
+module Database.Beam.MySQL.Extra.MariaDBVectorIntegrationSpec where
+
+import Control.Exception (bracket_)
+import Control.Monad (void)
+import Data.Text (Text)
+import Data.Text qualified as T
+import Database.Beam
+import Database.Beam.MySQL
+import Database.Beam.MySQL.Extra.MariaDBVector
+import Database.Beam.MySQL.Extra.Schema
+import Database.Beam.MySQL.Test.Connection
+import Database.Beam.MySQL.Test.ServerFlavor
+import Database.MySQL.Base qualified as MySQL
+import Test.Tasty
+import Test.Tasty.HUnit
+
+setupEmbedTable :: MySQL.MySQLConn -> IO ()
+setupEmbedTable conn = do
+    void $ MySQL.execute_ conn "DROP TABLE IF EXISTS embed"
+    void $
+        MySQL.execute_
+            conn
+            "CREATE TABLE embed (id INTEGER PRIMARY KEY NOT NULL AUTO_INCREMENT, vec VECTOR(3) NOT NULL)"
+
+teardownEmbedTable :: MySQL.MySQLConn -> IO ()
+teardownEmbedTable conn =
+    void $ MySQL.execute_ conn "DROP TABLE IF EXISTS embed"
+
+withEmbedTable :: IO MySQL.MySQLConn -> (MySQL.MySQLConn -> Assertion) -> Assertion
+withEmbedTable ioConn action = do
+    conn <- ioConn
+    bracket_ (setupEmbedTable conn) (teardownEmbedTable conn) (action conn)
+
+integrationTests :: IO MySQL.ConnectInfo -> TestTree
+integrationTests ioConnInfo = askOption $ \case
+    MariaDBServer -> mariadbIntegrationTests ioConnInfo
+    MySQLServer -> testGroup "MariaDBVector" []
+
+mariadbIntegrationTests :: IO MySQL.ConnectInfo -> TestTree
+mariadbIntegrationTests ioConnInfo =
+    withConnection ioConnInfo $ \ioConn ->
+        -- These tests share a single 'embed' table that each test
+        -- drop/creates, so they must not run concurrently.
+        dependentTestGroup
+            "MariaDBVector (requires MariaDB 11.7+)"
+            AllFinish
+            [ testCase "INSERT and SELECT round-trip preserves the vector" $
+                withEmbedTable ioConn $ \conn -> do
+                    let v1 = fromFloats [0.1, 0.2, 0.3]
+                        v2 = fromFloats [1.0, 2.0, 3.0]
+                    runDB conn $
+                        runInsert $
+                            insert embedDb.tableEmbed $
+                                insertValues
+                                    [ Embed 1 v1
+                                    , Embed 2 v2
+                                    ]
+
+                    rows <-
+                        runDB conn $
+                            runSelectReturningList $
+                                select $
+                                    orderBy_ (\e -> asc_ e.id) $
+                                        all_ embedDb.tableEmbed
+                    rows @?= [Embed 1 v1, Embed 2 v2]
+            , testCase "vecDistanceEuclidean_ orders rows by distance" $
+                withEmbedTable ioConn $ \conn -> do
+                    runDB conn $
+                        runInsert $
+                            insert embedDb.tableEmbed $
+                                insertValues
+                                    [ Embed 1 (fromFloats [0.0, 0.0, 0.0])
+                                    , Embed 2 (fromFloats [10.0, 0.0, 0.0])
+                                    , Embed 3 (fromFloats [1.0, 0.0, 0.0])
+                                    ]
+
+                    let target = val_ (fromFloats [0.0, 0.0, 0.0])
+                    ids <-
+                        runDB conn $
+                            runSelectReturningList $
+                                select $
+                                    fmap (.id) $
+                                        orderBy_ (\e -> asc_ (vecDistanceEuclidean_ e.vec target)) $
+                                            all_ embedDb.tableEmbed
+                    ids @?= [1, 3, 2]
+            , testCase "vecFromText_ parses JSON array literal" $
+                withEmbedTable ioConn $ \conn -> do
+                    runDB conn $
+                        runInsert $
+                            insert embedDb.tableEmbed $
+                                insertExpressions
+                                    [ Embed (val_ 1) (vecFromText_ (val_ ("[0.5, 1.5, 2.5]" :: Text)))
+                                    ]
+                    rows <-
+                        runDB conn $
+                            runSelectReturningList $
+                                select $
+                                    all_ embedDb.tableEmbed
+                    rows @?= [Embed 1 (fromFloats [0.5, 1.5, 2.5])]
+            , testCase "vecToText_ renders vector as JSON array" $
+                withEmbedTable ioConn $ \conn -> do
+                    runDB conn $
+                        runInsert $
+                            insert embedDb.tableEmbed $
+                                insertValues [Embed 1 (fromFloats [1.0, 2.0, 3.0])]
+
+                    -- VEC_ToText returns "[1.000000,2.000000,3.000000]" in
+                    -- current MariaDB versions; check key markers rather than
+                    -- exact formatting.
+                    texts <- runDB conn $
+                        runSelectReturningList $
+                            select $ do
+                                e <- all_ embedDb.tableEmbed
+                                return (vecToText_ e.vec :: QGenExpr QValueContext MySQL QBaseScope Text)
+                    case texts of
+                        [t] -> do
+                            assertBool ("text starts with [: " <> show t) ("[" `isPrefixOf'` t)
+                            assertBool ("text ends with ]: " <> show t) ("]" `isSuffixOf'` t)
+                        _ -> assertFailure $ "expected exactly one row, got: " <> show texts
+            ]
+  where
+    isPrefixOf' p t = case T.stripPrefix p t of
+        Just _ -> True
+        Nothing -> False
+    isSuffixOf' s t = case T.stripSuffix s t of
+        Just _ -> True
+        Nothing -> False

--- a/test/Database/Beam/MySQL/Extra/MariaDBVectorSpec.hs
+++ b/test/Database/Beam/MySQL/Extra/MariaDBVectorSpec.hs
@@ -1,0 +1,122 @@
+{-# LANGUAGE NoFieldSelectors #-}
+
+module Database.Beam.MySQL.Extra.MariaDBVectorSpec where
+
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as L
+import Data.Either (isLeft)
+import Data.Text (Text)
+import Database.Beam
+import Database.Beam.MySQL
+import Database.Beam.MySQL.Extra.MariaDBVector
+import Database.Beam.MySQL.Extra.Schema
+import Database.Beam.MySQL.Syntax.SelectTable
+import Database.Beam.MySQL.Test.Util
+import Database.MySQL.Base
+import Test.Tasty
+import Test.Tasty.HUnit
+
+tests :: TestTree
+tests =
+    testGroup
+        "MariaDBVector"
+        [ conversionTests
+        , syntaxTests
+        ]
+
+conversionTests :: TestTree
+conversionTests =
+    testGroup
+        "fromFloats / toFloats"
+        [ testCase "round-trip empty list" $
+            toFloats (fromFloats []) @?= Right []
+        , testCase "round-trip single element" $
+            toFloats (fromFloats [1.5]) @?= Right [1.5]
+        , testCase "round-trip multiple elements" $
+            toFloats (fromFloats [0.1, -2.5, 3.14, 0.0]) @?= Right [0.1, -2.5, 3.14, 0.0]
+        , testCase "fromFloats [] yields empty bytes" $
+            unMariaDBVector (fromFloats []) @?= BS.empty
+        , testCase "fromFloats [1.0] is IEEE 754 LE" $
+            -- 1.0 in IEEE 754 single precision = 0x3F800000, little-endian on disk
+            unMariaDBVector (fromFloats [1.0]) @?= BS.pack [0x00, 0x00, 0x80, 0x3F]
+        , testCase "fromFloats [-1.0] is IEEE 754 LE" $
+            unMariaDBVector (fromFloats [-1.0]) @?= BS.pack [0x00, 0x00, 0x80, 0xBF]
+        , testCase "fromFloats [0.0] is all zeros" $
+            unMariaDBVector (fromFloats [0.0]) @?= BS.pack [0x00, 0x00, 0x00, 0x00]
+        , testCase "fromFloats packs floats in order" $
+            unMariaDBVector (fromFloats [1.0, 2.0])
+                @?= BS.pack [0x00, 0x00, 0x80, 0x3F, 0x00, 0x00, 0x00, 0x40]
+        , testCase "toFloats parses empty bytes as empty list" $
+            toFloats (MariaDBVector BS.empty) @?= Right []
+        , testCase "toFloats rejects 1-byte input" $
+            isLeft (toFloats (MariaDBVector (BS.pack [0x00]))) @? "expected Left"
+        , testCase "toFloats rejects 5-byte input (not multiple of 4)" $
+            isLeft (toFloats (MariaDBVector (BS.pack [0x00, 0x00, 0x80, 0x3F, 0x00])))
+                @? "expected Left"
+        ]
+
+syntaxTests :: TestTree
+syntaxTests =
+    testGroup
+        "SQL syntax"
+        [ testCase "vecDistance_ emits VEC_DISTANCE" $ do
+            let q =
+                    select $ do
+                        e <- all_ embedDb.tableEmbed
+                        return (e.id, vecDistance_ e.vec (val_ (fromFloats [1.0, 2.0])))
+            assertSqlSelect
+                q
+                "SELECT `t0`.`id` AS `res0`,VEC_DISTANCE(`t0`.`vec`,?) AS `res1` FROM `embed` AS `t0`"
+                [MySQLBytes (unMariaDBVector (fromFloats [1.0, 2.0]))]
+        , testCase "vecDistanceCosine_ emits VEC_DISTANCE_COSINE" $ do
+            let q =
+                    select $ do
+                        e <- all_ embedDb.tableEmbed
+                        return (e.id, vecDistanceCosine_ e.vec (val_ (fromFloats [1.0])))
+            assertSqlSelect
+                q
+                "SELECT `t0`.`id` AS `res0`,VEC_DISTANCE_COSINE(`t0`.`vec`,?) AS `res1` FROM `embed` AS `t0`"
+                [MySQLBytes (unMariaDBVector (fromFloats [1.0]))]
+        , testCase "vecDistanceEuclidean_ emits VEC_DISTANCE_EUCLIDEAN" $ do
+            let q =
+                    select $ do
+                        e <- all_ embedDb.tableEmbed
+                        return (e.id, vecDistanceEuclidean_ e.vec (val_ (fromFloats [1.0])))
+            assertSqlSelect
+                q
+                "SELECT `t0`.`id` AS `res0`,VEC_DISTANCE_EUCLIDEAN(`t0`.`vec`,?) AS `res1` FROM `embed` AS `t0`"
+                [MySQLBytes (unMariaDBVector (fromFloats [1.0]))]
+        , testCase "vecFromText_ emits VEC_FromText" $ do
+            let q =
+                    select $ do
+                        e <- all_ embedDb.tableEmbed
+                        return (e.id, vecDistance_ e.vec (vecFromText_ (val_ ("[1,2,3]" :: Text))))
+            assertSqlSelect
+                q
+                "SELECT `t0`.`id` AS `res0`,VEC_DISTANCE(`t0`.`vec`,VEC_FromText(?)) AS `res1` FROM `embed` AS `t0`"
+                [MySQLText "[1,2,3]"]
+        , testCase "vecToText_ emits VEC_ToText" $ do
+            let q =
+                    select $ do
+                        e <- all_ embedDb.tableEmbed
+                        return (e.id, vecToText_ e.vec :: QGenExpr QValueContext MySQL QBaseScope Text)
+            assertSqlSelect
+                q
+                "SELECT `t0`.`id` AS `res0`,VEC_ToText(`t0`.`vec`) AS `res1` FROM `embed` AS `t0`"
+                []
+        , testCase "vecDistance_ in ORDER BY for nearest-neighbour search" $ do
+            let q =
+                    select $
+                        orderBy_ (\(_, d) -> asc_ d) $ do
+                            e <- all_ embedDb.tableEmbed
+                            return (e.id, vecDistance_ e.vec (val_ (fromFloats [0.0, 0.0])))
+            assertSqlSelect
+                q
+                "SELECT `t0`.`id` AS `res0`,VEC_DISTANCE(`t0`.`vec`,?) AS `res1` FROM `embed` AS `t0` ORDER BY VEC_DISTANCE(`t0`.`vec`,?) ASC"
+                [ MySQLBytes (unMariaDBVector (fromFloats [0.0, 0.0]))
+                , MySQLBytes (unMariaDBVector (fromFloats [0.0, 0.0]))
+                ]
+        ]
+
+assertSqlSelect :: SqlSelect MySQL a -> L.ByteString -> [MySQLValue] -> Assertion
+assertSqlSelect (SqlSelect q) = assertMySQLSyntax (fromMySQLSelect q)

--- a/test/Database/Beam/MySQL/Extra/Schema.hs
+++ b/test/Database/Beam/MySQL/Extra/Schema.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE NoFieldSelectors #-}
+
+module Database.Beam.MySQL.Extra.Schema where
+
+import Data.Int
+import Data.List.NonEmpty qualified as NE
+import Data.Text (Text)
+import Database.Beam
+import Database.Beam.MySQL.Extra.MariaDBVector
+import Database.Beam.Schema.Tables (RenamableWithRule (renamingFields))
+
+data EmbedT f = Embed
+    { id :: Columnar f Int32
+    , vec :: Columnar f MariaDBVector
+    }
+    deriving stock (Generic)
+    deriving anyclass (Beamable)
+type Embed = EmbedT Identity
+deriving instance Show Embed
+deriving instance Eq Embed
+
+instance Table EmbedT where
+    data PrimaryKey EmbedT f
+        = EmbedId (Columnar f Int32)
+        deriving stock (Generic)
+        deriving anyclass (Beamable)
+    primaryKey = EmbedId . (.id)
+
+newtype EmbedDb f = EmbedDb
+    { tableEmbed :: f (TableEntity EmbedT)
+    }
+    deriving stock (Generic)
+    deriving anyclass (Database be)
+
+embedDb :: DatabaseSettings be EmbedDb
+embedDb =
+    defaultDbSettings
+        `withDbModification` renamingFields fieldNamer
+  where
+    fieldNamer :: NE.NonEmpty Text -> Text
+    fieldNamer (n NE.:| _) = n

--- a/test/Database/Beam/MySQL/Test/Connection.hs
+++ b/test/Database/Beam/MySQL/Test/Connection.hs
@@ -1,0 +1,18 @@
+module Database.Beam.MySQL.Test.Connection
+    ( withConnection
+    , runDB
+    ) where
+
+import Database.Beam.MySQL (MySQLM, runBeamMySQLM)
+import Database.MySQL.Base qualified as MySQL
+import Test.Tasty (TestTree, withResource)
+
+withConnection :: IO MySQL.ConnectInfo -> (IO MySQL.MySQLConn -> TestTree) -> TestTree
+withConnection ioConnInfo = withResource doConnect MySQL.close
+  where
+    doConnect = do
+        connInfo <- ioConnInfo
+        MySQL.connect connInfo
+
+runDB :: MySQL.MySQLConn -> MySQLM a -> IO a
+runDB conn = MySQL.withTransaction conn . runBeamMySQLM conn

--- a/test/Database/Beam/MySQL/Test/Integration.hs
+++ b/test/Database/Beam/MySQL/Test/Integration.hs
@@ -3,18 +3,11 @@ module Database.Beam.MySQL.Test.Integration where
 import Control.Exception
 import Control.Monad
 import Database.Beam
-import Database.Beam.MySQL
+import Database.Beam.MySQL.Test.Connection
 import Database.Beam.MySQL.Test.Schema
 import Database.MySQL.Base qualified as MySQL
 import Test.Tasty
 import Test.Tasty.HUnit
-
-withConnection :: IO MySQL.ConnectInfo -> (IO MySQL.MySQLConn -> TestTree) -> TestTree
-withConnection ioConnInfo = withResource doConnect MySQL.close
-  where
-    doConnect = do
-        connInfo <- ioConnInfo
-        MySQL.connect connInfo
 
 setup :: IO MySQL.MySQLConn -> IO MySQL.MySQLConn
 setup ioConn = do
@@ -33,9 +26,6 @@ teardown conn = do
 
 withTestDB :: IO MySQL.MySQLConn -> (MySQL.MySQLConn -> Assertion) -> Assertion
 withTestDB ioConn = bracket (setup ioConn) teardown
-
-runDB :: MySQL.MySQLConn -> MySQLM a -> IO a
-runDB conn = MySQL.withTransaction conn . runBeamMySQLM conn
 
 integrationTests :: IO MySQL.ConnectInfo -> TestTree
 integrationTests ioConnInfo =

--- a/test/Database/Beam/MySQL/Test/ServerFlavor.hs
+++ b/test/Database/Beam/MySQL/Test/ServerFlavor.hs
@@ -1,0 +1,32 @@
+-- | Tasty option for selecting which server flavor (MariaDB or MySQL) the
+-- integration tests should run against. Set via @--server-flavor=mariadb@ on
+-- the command line or @TASTY_SERVER_FLAVOR=mariadb@ in the environment.
+-- Default is 'MariaDB' so that vendor-specific tests fail loudly when run
+-- against the wrong server, rather than silently being skipped.
+module Database.Beam.MySQL.Test.ServerFlavor
+    ( ServerFlavor (..)
+    , serverFlavorOption
+    ) where
+
+import Data.Proxy (Proxy (..))
+import Data.Tagged (Tagged)
+import Test.Tasty.Options (IsOption (..), OptionDescription (..))
+
+data ServerFlavor
+    = MariaDBServer
+    | MySQLServer
+    deriving stock (Show, Eq)
+
+instance IsOption ServerFlavor where
+    defaultValue = MariaDBServer
+    parseValue = \case
+        "mariadb" -> Just MariaDBServer
+        "mysql" -> Just MySQLServer
+        _ -> Nothing
+    optionName = pure "server-flavor" :: Tagged ServerFlavor String
+    optionHelp =
+        pure "Server flavor under test (mariadb, mysql). Default: mariadb."
+            :: Tagged ServerFlavor String
+
+serverFlavorOption :: OptionDescription
+serverFlavorOption = Option (Proxy :: Proxy ServerFlavor)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -4,8 +4,11 @@ module Main where
 
 import Control.Exception
 import Control.Monad
+import Database.Beam.MySQL.Extra.MariaDBVectorIntegrationSpec qualified
+import Database.Beam.MySQL.Extra.MariaDBVectorSpec qualified
 import Database.Beam.MySQL.Syntax.Spec qualified
 import Database.Beam.MySQL.Test.Integration qualified
+import Database.Beam.MySQL.Test.ServerFlavor (serverFlavorOption)
 import Database.MySQL.Base (ConnectInfo (..))
 import Database.MySQL.Base qualified as MySQL
 import Test.Tasty as Tasty
@@ -24,8 +27,10 @@ import System.Environment
 #endif
 
 main :: IO ()
-main = do
-    defaultMain allTests
+main =
+    defaultMainWithIngredients
+        (includingOptions [serverFlavorOption] : defaultIngredients)
+        allTests
 
 allTests :: TestTree
 allTests =
@@ -40,6 +45,7 @@ tests =
     testGroup
         "unit Database.Beam.MySQL"
         [ Database.Beam.MySQL.Syntax.Spec.tests
+        , Database.Beam.MySQL.Extra.MariaDBVectorSpec.tests
         ]
 
 integrationTests :: IO MySQL.ConnectInfo -> TestTree
@@ -47,6 +53,7 @@ integrationTests ioConnInfo =
     testGroup
         "integration"
         [ Database.Beam.MySQL.Test.Integration.integrationTests ioConnInfo
+        , Database.Beam.MySQL.Extra.MariaDBVectorIntegrationSpec.integrationTests ioConnInfo
         ]
 
 #ifdef USE_TEST_CONTAINER


### PR DESCRIPTION
## Summary
- Add `MariaDBVector` newtype wrapping MariaDB 11.7+'s `VECTOR(N)` binary representation, with `fromFloats` / `toFloats` for `[Float]` conversion
- Expose distance functions `vecDistance_`, `vecDistanceCosine_`, `vecDistanceEuclidean_` for use in queries (e.g. `ORDER BY` for nearest-neighbour search)
- Expose text conversion functions `vecFromText_` / `vecToText_` wrapping `VEC_FromText` / `VEC_ToText`
- Add unit tests for the binary round-trip and an integration test suite that exercises the SQL functions against a live MariaDB instance
- Gate vector integration tests on server flavor (MariaDB 11.7+) and thread the flavor through the haskell-ci matrix

## Test plan
- [x] Unit tests for `fromFloats` / `toFloats` round-trip
- [x] Integration tests against MariaDB with `VECTOR` columns (skipped on MySQL / older MariaDB via server-flavor gating)