### PR TITLE
Bump version: 0.11.0.0 → 0.11.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,10 @@ and this project adheres to the
 
 ## Unreleased
 
+## 0.11.1.0 - 2026-05-31
+
+### Added
+
+- `Database.Beam.MySQL.Extra.MariaDBVector`: support for MariaDB `VECTOR` columns.
+
 ## 0.1.0.0 - YYYY-MM-DD

--- a/beam-mysql-haskell.cabal
+++ b/beam-mysql-haskell.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           beam-mysql-haskell
-version:        0.11.0.0
+version:        0.11.1.0
 synopsis:       Beam driver for mysql-haskell
 description:    Beam driver for the MySQL database with the pure haskell driver <https://hackage.haskell.org/package/mysql-haskell mysql-haskell>. Please see the README on GitHub at <https://github.com/himura/beam-mysql-haskell#readme>
 category:       Database

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                beam-mysql-haskell
-version:             0.11.0.0
+version:             0.11.1.0
 github:              "himura/beam-mysql-haskell"
 license:             MIT
 license-file:        LICENSE


### PR DESCRIPTION
## Summary

Version bump `0.11.0.0` → `0.11.1.0 for the new MariaDB `VECTOR` support added in `Database.Beam.MySQL.Extra.MariaDBVector`.